### PR TITLE
Extend Configuration

### DIFF
--- a/dtui/ConfigurationManager.cs
+++ b/dtui/ConfigurationManager.cs
@@ -49,6 +49,8 @@ namespace dtui
             Console.OutputEncoding = Configuration.Language switch
             {
                 Language.Japanese => Encoding.GetEncoding(932),
+                Language.Chinese => Encoding.GetEncoding(936),
+                Language.Spanish => Encoding.GetEncoding(1252),
                 _ => Encoding.Default
             };
         }

--- a/dtui/ConfigurationManager.cs
+++ b/dtui/ConfigurationManager.cs
@@ -32,13 +32,7 @@ namespace dtui
 
             if (!File.Exists(Path))
             {
-                var config = new Configuration
-                {
-                    Language = Language.English
-                };
-
-                string data = JsonConvert.SerializeObject(config, JsonSettings);
-
+                string data = JsonConvert.SerializeObject(new Configuration(), JsonSettings);
                 File.WriteAllText(Path, data);
             }
         }

--- a/dtui/Discord.cs
+++ b/dtui/Discord.cs
@@ -2,12 +2,16 @@
 {
     public class Discord
     {
-        public static async Task<bool> Login(string? username, string? password)
+        public static async Task<bool> Login(string? username, string? password, CancellationToken cancellationToken)
         {
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            bool valid = !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password);
-            Console.WriteLine($"u:{username}\tp:{password}\t(valid: {valid})");
-            return valid;
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return !string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password);
         }
     }
 }

--- a/dtui/Model/Configuration.cs
+++ b/dtui/Model/Configuration.cs
@@ -1,11 +1,48 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+using Terminal.Gui;
 
 namespace dtui
 {
     [Serializable]
+    public class TextColor
+    {
+        [JsonProperty(PropertyName = "forecolor")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Color ForeColor { get; set; }
+
+        [JsonProperty(PropertyName = "backcolor")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Color BackColor { get; set; }
+    }
+
+    [Serializable]
+    public class ColorScheme
+    {
+        [JsonProperty(PropertyName = "disabled")]
+        public TextColor Disabled { get; init; } = new TextColor { ForeColor = Color.DarkGray, BackColor = Color.Black };
+
+        [JsonProperty(PropertyName = "normal")]
+        public TextColor Normal { get; init; } = new TextColor { ForeColor = Color.Gray, BackColor = Color.Black };
+
+        [JsonProperty(PropertyName = "hot-normal")]
+        public TextColor HotNormal { get; init; } = new TextColor { ForeColor = Color.Magenta, BackColor = Color.Black };
+
+        [JsonProperty(PropertyName = "focus")]
+        public TextColor Focus { get; init; } = new TextColor { ForeColor = Color.BrightMagenta, BackColor = Color.Gray };
+
+        [JsonProperty(PropertyName = "hot-focus")]
+        public TextColor HotFocus { get; init; } = new TextColor { ForeColor = Color.White, BackColor = Color.Black };
+    }
+
+    [Serializable]
     public class Configuration
     {
         [JsonProperty(PropertyName = "language", Required = Required.Always)]
-        public string Language { get; init; } = string.Empty;
+        public string Language { get; set; } = dtui.Language.English;
+
+        [JsonProperty(PropertyName = "colorscheme")]
+        public dtui.ColorScheme ColorScheme { get; set; } = new dtui.ColorScheme();
     }
 }

--- a/dtui/Program.cs
+++ b/dtui/Program.cs
@@ -15,10 +15,10 @@ namespace dtui
         public static int Main(string[] args)
         {
             ConfigurationManager.Init();
-            var configuration = ConfigurationManager.Configuration;
             ConfigurationManager.ChangeCulture();
 
             var assembly = Assembly.GetExecutingAssembly();
+            var configuration = ConfigurationManager.Configuration;
             var resourceManager = new ResourceManager($"dtui.i18n.string.{configuration.Language}", assembly);
 
             var app = new CommandLineApplication
@@ -42,14 +42,15 @@ namespace dtui
 
                     Application.Init();
                     var toplevel = Application.Top;
+                    var colorscheme = configuration.ColorScheme;
 
-                    Colors.Base = new ColorScheme()
+                    Colors.Base = new Terminal.Gui.ColorScheme()
                     {
-                        Normal = Application.Driver.MakeAttribute(Color.Gray, Color.Black),
-                        Disabled = Application.Driver.MakeAttribute(Color.DarkGray, Color.Black),
-                        Focus = Application.Driver.MakeAttribute(Color.BrightMagenta, Color.Gray),
-                        HotFocus = Application.Driver.MakeAttribute(Color.White, Color.Black),
-                        HotNormal = Application.Driver.MakeAttribute(Color.Magenta, Color.Black)
+                        Disabled = Application.Driver.MakeAttribute(colorscheme.Disabled.ForeColor, colorscheme.Disabled.BackColor),
+                        Normal = Application.Driver.MakeAttribute(colorscheme.Normal.ForeColor, colorscheme.Normal.BackColor),
+                        HotNormal = Application.Driver.MakeAttribute(colorscheme.HotNormal.ForeColor, colorscheme.HotNormal.BackColor),
+                        Focus = Application.Driver.MakeAttribute(colorscheme.Focus.ForeColor, colorscheme.Focus.BackColor),
+                        HotFocus = Application.Driver.MakeAttribute(colorscheme.HotFocus.ForeColor, colorscheme.HotFocus.BackColor)
                     };
 
                     RxApp.MainThreadScheduler = TerminalScheduler.Default;

--- a/dtui/Properties/launchSettings.json
+++ b/dtui/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "dtui": {
       "commandName": "Project",
-      "commandLineArgs": "run -usc"
+      "commandLineArgs": "run"
     }
   }
 }

--- a/dtui/View/LoginView.cs
+++ b/dtui/View/LoginView.cs
@@ -38,7 +38,7 @@ namespace dtui
 
         TextField GetUsernameInput(View previous)
         {
-            TextField usernameInput = new() { X = previous.Text.Length + 2, Y = Pos.Top(previous), Width = 40 };
+            TextField usernameInput = new() { X = previous.Text.Length + (Language.IsAsian(Configuration.Language) ? -2 : 2), Y = Pos.Top(previous), Width = 40 };
 
             ViewModel
                 .WhenAnyValue(x => x.Username)
@@ -66,7 +66,7 @@ namespace dtui
 
         TextField GetPasswordInput(View previous)
         {
-            TextField passwordInput = new() { X = previous.Text.Length + 2, Y = Pos.Top(previous), Width = 40, Secret = true };
+            TextField passwordInput = new() { X = previous.Text.Length + (Language.IsAsian(Configuration.Language) ? -2 : 2), Y = Pos.Top(previous), Width = 40, Secret = true };
 
             ViewModel
                 .WhenAnyValue(x => x.Password)
@@ -100,10 +100,25 @@ namespace dtui
             return loginButton;
         }
 
+        Button GetCancelButton(View previous)
+        {
+            Button cancelButton = new(ResourceManager.GetString("CancelButton")) { X = Pos.Left(previous), Y = Pos.Top(previous) };
+            cancelButton.X -= cancelButton.Text.Length + (Language.IsAsian(Configuration.Language) ? 0 : 4) + 2;
+
+            cancelButton
+                .Events()
+                .Clicked
+                .InvokeCommand(ViewModel, x => x.Cancel)
+                .DisposeWith(_disposable);
+
+            Add(cancelButton);
+            return cancelButton;
+        }
+
         Button GetExitButton(View previus)
         {
             Button exitButton = new(ResourceManager.GetString("ExitButton")) { X = Pos.Left(previus), Y = Pos.Top(previus) };
-            exitButton.X -= exitButton.Text.Length + 4 + 2;
+            exitButton.X -= exitButton.Text.Length + (Language.IsAsian(Configuration.Language) ? 3 : 4) + 2;
 
             exitButton
                 .Events()
@@ -128,7 +143,6 @@ namespace dtui
                 .BindTo(progressLabel, x => x.Text)
                 .DisposeWith(_disposable);
 
-
             Add(progressLabel);
             return progressLabel;
         }
@@ -145,9 +159,9 @@ namespace dtui
             Label passwordLabel = GetPasswordLabel(usernameLabel);
             TextField passwordInput = GetPasswordInput(passwordLabel);
             Button loginButton = GetLoginButton(passwordInput);
-            Button exitButton = GetExitButton(loginButton);
-
-            GetProgressLabel(titleLabel, loginButton);
+            Label progressLabel = GetProgressLabel(titleLabel, loginButton);
+            Button cancelButton = GetCancelButton(loginButton);
+            Button exitButton = GetExitButton(cancelButton);
         }
 
         object IViewFor.ViewModel

--- a/dtui/View/LoginView.cs
+++ b/dtui/View/LoginView.cs
@@ -38,7 +38,7 @@ namespace dtui
 
         TextField GetUsernameInput(View previous)
         {
-            TextField usernameInput = new() { X = previous.Text.Length + (Language.IsAsian(Configuration.Language) ? -2 : 2), Y = Pos.Top(previous), Width = 40 };
+            TextField usernameInput = new() { X = previous.Text.Sum(x => Rune.ColumnWidth(x)) + 3, Y = Pos.Top(previous), Width = 40 };
 
             ViewModel
                 .WhenAnyValue(x => x.Username)
@@ -66,7 +66,7 @@ namespace dtui
 
         TextField GetPasswordInput(View previous)
         {
-            TextField passwordInput = new() { X = previous.Text.Length + (Language.IsAsian(Configuration.Language) ? -2 : 2), Y = Pos.Top(previous), Width = 40, Secret = true };
+            TextField passwordInput = new() { X = previous.Text.Sum(x => Rune.ColumnWidth(x)) + 3, Y = Pos.Top(previous), Width = 40, Secret = true };
 
             ViewModel
                 .WhenAnyValue(x => x.Password)
@@ -88,7 +88,7 @@ namespace dtui
         Button GetLoginButton(View previous)
         {
             Button loginButton = new(ResourceManager.GetString("LoginButton")) { Y = Pos.Top(previous) + 2 };
-            loginButton.X = Pos.Right(previous) - loginButton.Text.Length - (Language.IsAsian(Configuration.Language) ? 0 : 4);
+            loginButton.X = Pos.Right(previous) - loginButton.Text.Sum(x => Rune.ColumnWidth(x)) - 4;
 
             loginButton
                 .Events()
@@ -103,7 +103,7 @@ namespace dtui
         Button GetCancelButton(View previous)
         {
             Button cancelButton = new(ResourceManager.GetString("CancelButton")) { X = Pos.Left(previous), Y = Pos.Top(previous) };
-            cancelButton.X -= cancelButton.Text.Length + (Language.IsAsian(Configuration.Language) ? 0 : 4) + 2;
+            cancelButton.X -= cancelButton.Text.Sum(x => Rune.ColumnWidth(x)) + 6;
 
             cancelButton
                 .Events()
@@ -118,7 +118,7 @@ namespace dtui
         Button GetExitButton(View previus)
         {
             Button exitButton = new(ResourceManager.GetString("ExitButton")) { X = Pos.Left(previus), Y = Pos.Top(previus) };
-            exitButton.X -= exitButton.Text.Length + (Language.IsAsian(Configuration.Language) ? 3 : 4) + 2;
+            exitButton.X -= exitButton.Text.Sum(x => Rune.ColumnWidth(x)) + 6;
 
             exitButton
                 .Events()

--- a/dtui/i18n/string.en_US.resx
+++ b/dtui/i18n/string.en_US.resx
@@ -117,11 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CancelButton" xml:space="preserve">
+    <value>cancel</value>
+  </data>
   <data name="ExitButton" xml:space="preserve">
     <value>exit</value>
   </data>
   <data name="LoginButton" xml:space="preserve">
     <value>login</value>
+  </data>
+  <data name="LoginCancelled" xml:space="preserve">
+    <value>cancelled login</value>
+  </data>
+  <data name="LoginCancelledMessage" xml:space="preserve">
+    <value>login has been cancelled successfully</value>
   </data>
   <data name="LoginError" xml:space="preserve">
     <value>login error</value>

--- a/dtui/i18n/string.ja_JP.resx
+++ b/dtui/i18n/string.ja_JP.resx
@@ -117,11 +117,20 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CancelButton" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
   <data name="ExitButton" xml:space="preserve">
     <value>終了</value>
   </data>
   <data name="LoginButton" xml:space="preserve">
     <value>ログイン</value>
+  </data>
+  <data name="LoginCancelled" xml:space="preserve">
+    <value>ログインキャンセル済み</value>
+  </data>
+  <data name="LoginCancelledMessage" xml:space="preserve">
+    <value>ログインは正常にキャンセルされました</value>
   </data>
   <data name="LoginError" xml:space="preserve">
     <value>ログインに失敗しました</value>


### PR DESCRIPTION
Extend configuration. Users now can set the colorscheme of dtui
in settings.json themselves by overwriting the defaults. Color
values are not case-sensitive and are based off Terminal.Gui's
Color enumeration.
